### PR TITLE
fix(lwjgl3): fix and split char and raw key handler

### DIFF
--- a/src/main/java/org/terasology/computer/ui/ComputerTerminalWidget.java
+++ b/src/main/java/org/terasology/computer/ui/ComputerTerminalWidget.java
@@ -3,8 +3,7 @@
 package org.terasology.computer.ui;
 
 import org.joml.Rectanglei;
-import org.terasology.math.JomlUtil;
-import org.terasology.utilities.Assets;
+import org.joml.Vector2i;
 import org.terasology.computer.context.ComputerConsole;
 import org.terasology.computer.event.server.ConsoleListeningRegistrationEvent;
 import org.terasology.computer.event.server.CopyProgramEvent;
@@ -22,16 +21,18 @@ import org.terasology.input.device.KeyboardDevice;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.clipboard.ClipboardManager;
 import org.terasology.logic.common.DisplayNameComponent;
-import org.joml.Vector2i;
+import org.terasology.math.JomlUtil;
 import org.terasology.network.ClientComponent;
-import org.terasology.rendering.assets.font.Font;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.Color;
 import org.terasology.nui.CoreWidget;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.LayoutConfig;
 import org.terasology.nui.VerticalAlign;
+import org.terasology.nui.events.NUICharEvent;
 import org.terasology.nui.events.NUIKeyEvent;
+import org.terasology.rendering.assets.font.Font;
+import org.terasology.utilities.Assets;
 
 import java.util.Collection;
 
@@ -206,22 +207,33 @@ public class ComputerTerminalWidget extends CoreWidget {
 
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {
-        if (isFocused()) {
-            int keyboardCharId = event.getKey().getId();
-            if (event.isDown()) {
-                char character = 'x'; // event.getKeyCharacter(); TODO: Fix - onCharEvent from UIWidget has char, but not id, this uses both ..
-                if (mode == TerminalMode.PLAYER_CONSOLE) {
-                    if (editingProgram) {
-                        KeyboardDevice keyboard = event.getKeyboard();
-                        programEditingConsoleGui.keyTypedInEditingProgram(character, keyboardCharId,
-                                keyboard.isKeyDown(Keyboard.KeyId.LEFT_CTRL) || keyboard.isKeyDown(Keyboard.KeyId.RIGHT_CTRL));
-                    } else {
-                        playerCommandConsoleGui.keyTypedInPlayerConsole(character, keyboardCharId);
-                    }
-                }
+        int keyboardCharId = event.getKey().getId();
+        if (mode == TerminalMode.PLAYER_CONSOLE) {
+            if (editingProgram) {
+                KeyboardDevice keyboard = event.getKeyboard();
+                programEditingConsoleGui.keyTypedInEditingProgram(keyboardCharId,
+                        keyboard.isKeyDown(Keyboard.KeyId.LEFT_CTRL) || keyboard.isKeyDown(Keyboard.KeyId.RIGHT_CTRL));
+            } else {
+                playerCommandConsoleGui.keyTypedInPlayerConsole(keyboardCharId);
             }
-            if (keyboardCharId != Keyboard.KeyId.ESCAPE) {
-                return true;
+        }
+        if (event.getKey().getId() != Keyboard.KeyId.ESCAPE) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean onCharEvent(NUICharEvent event) {
+        char character = event.getCharacter();
+        if (mode == TerminalMode.PLAYER_CONSOLE) {
+            if (editingProgram) {
+                KeyboardDevice keyboard = event.getKeyboard();
+                programEditingConsoleGui.charTypedInEditinProgram(character,
+                        keyboard.isKeyDown(Keyboard.KeyId.LEFT_CTRL) || keyboard.isKeyDown(Keyboard.KeyId.RIGHT_CTRL));
+            } else {
+                playerCommandConsoleGui.charTypedInPlayerConsole(character);
             }
         }
         return false;

--- a/src/main/java/org/terasology/computer/ui/PlayerCommandConsoleGui.java
+++ b/src/main/java/org/terasology/computer/ui/PlayerCommandConsoleGui.java
@@ -3,9 +3,9 @@
 package org.terasology.computer.ui;
 
 import org.terasology.computer.context.ComputerConsole;
+import org.terasology.input.Keyboard;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.Color;
-import org.terasology.input.Keyboard;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -56,18 +56,26 @@ public class PlayerCommandConsoleGui {
             if (focused) {
                 blinkDrawTick = ((++blinkDrawTick) % BLINK_LENGTH);
                 if (blinkDrawTick * 2 > BLINK_LENGTH) {
-                    computerTerminalWidget.drawVerticalLine(canvas, x + cursorPositionInDisplayedCommandLine * characterWidth - 1, 1 + lastLineY, lastLineY + fontHeight, PLAYER_CONSOLE_CURSOR_COLOR);
+                    computerTerminalWidget.drawVerticalLine(canvas,
+                            x + cursorPositionInDisplayedCommandLine * characterWidth - 1, 1 + lastLineY,
+                            lastLineY + fontHeight, PLAYER_CONSOLE_CURSOR_COLOR);
                 }
             }
         }
     }
 
-    public void keyTypedInPlayerConsole(char character, int keyboardCharId) {
+    public void charTypedInPlayerConsole(char character) {
         if (!readOnly) {
             if (character >= 32 && character < 127) {
                 currentCommand.insert(cursorPositionInPlayerCommand, character);
                 cursorPositionInPlayerCommand++;
-            } else if (keyboardCharId == Keyboard.KeyId.BACKSPACE && cursorPositionInPlayerCommand > 0) {
+            }
+        }
+    }
+
+    public void keyTypedInPlayerConsole(int keyboardCharId) {
+        if (!readOnly) {
+            if (keyboardCharId == Keyboard.KeyId.BACKSPACE && cursorPositionInPlayerCommand > 0) {
                 currentCommand.delete(cursorPositionInPlayerCommand - 1, cursorPositionInPlayerCommand);
                 cursorPositionInPlayerCommand--;
             } else if (keyboardCharId == Keyboard.KeyId.DELETE && cursorPositionInPlayerCommand < currentCommand.length()) {


### PR DESCRIPTION
###Contains

Splitting key and char event handler. 
This needs after LWJGL3 introduce. It handle raw keys and text input separately.
Fixes #11 

### How To Test

1. create world with ModularComputers
2. Place Monitor and setup modular computer ( idk case, you must works with console or/and program editing)
3. Open console and try input: 
    1. any english chars (seems, en Layout must be enabled)
    2. Try DELETE, BACKSPACE, LEFT, RIGHT, HOME,END, ENTER, UP, DOWN keys (P.S. UP -DOWN works with history commands)
4. Open program editing(terminal) and try input:
    1. any english chars (seems, en Layout must be enabled)
    2. DELETE and BACKSPACE Keys
    3. UP, DOWN, LEFT,RIGHT Keys
    4. HOME, END Keys
    5. ENTER key
    6. Ctrl+UP, Ctrl+DOWN (right and left Ctrl keys) - text scale changing.
    7. Ctrl+S - saving
    8. Ctrl+X - exit - appears question
        8.1. try any chars except Y and N,  terminal must not receive any char.
        8.2. type Y or N. - Must be KeyModifier independent(works with any Ctrl/shift/alt key pressed)
    9. Ctrl+E - display error (seems must be used after script compilation failed)
   10. Ctrl+G - GoTo line - there you must type digit for go to line.
        10.1. typing any chars except digits, terminal must not receive any char.
        10.2  type digits must  appears.
        10.3  press enter must invoke goto line with typed digits before (not sure)
   11. Ctrl+V - Paste from clipboard


  
        
   
